### PR TITLE
 Replace usleep through QThread::usleep

### DIFF
--- a/src/backup.cpp
+++ b/src/backup.cpp
@@ -28,6 +28,7 @@
 
 #include <QtCore/QDir>
 #include <QtCore/QTextStream>
+#include <QtCore/QThread>
 #include <QtGui/QLayout>
 #include <QtGui/QLabel>
 #include <QtGui/QPushButton>
@@ -46,9 +47,6 @@
 #include <KDE/KProgressDialog>
 #include <KDE/KMessageBox>
 #include <KDE/KVBox>
-
-#include <unistd.h> // usleep()
-
 
 /**
  * Backups are wrapped in a .tar.gz, inside that folder name.
@@ -235,7 +233,7 @@ void BackupDialog::backup()
     while (thread.isRunning()) {
         progress->setValue(progress->value() + 1); // Or else, the animation is not played!
         kapp->processEvents();
-        usleep(300); // Not too long because if the backup process is finished, we wait for nothing
+        QThread::usleep(300); // Then sleep, but not too long because if the backup process is finished, we wait for nothing
     }
 
     Settings::setLastBackup(QDate::currentDate());
@@ -294,7 +292,7 @@ void BackupDialog::restore()
     while (thread.isRunning()) {
         progress->setValue(progress->value() + 1); // Or else, the animation is not played!
         kapp->processEvents();
-        usleep(300); // Not too long because if the restore process is finished, we wait for nothing
+        QThread::usleep(300); // Then sleep, but not too long because if the backup process is finished, we wait for nothing
     }
 
     dialog->hide(); // The restore is finished, do not continue to show it while telling the user the application is going to be restarted

--- a/src/bnpview.cpp
+++ b/src/bnpview.cpp
@@ -23,6 +23,7 @@
 #include <QtCore/QList>
 #include <QtCore/QRegExp>
 #include <QtCore/QEvent>
+#include <QtCore/QThread>
 #include <QtGui/QStackedWidget>
 #include <QtGui/QPixmap>
 #include <QtGui/QImage>
@@ -61,7 +62,6 @@
 #endif //BASKET_USE_DRKONQI
 
 #include <cstdlib>
-#include <unistd.h> // usleep
 
 #include "basketscene.h"
 #include "decoratedbasket.h"
@@ -2065,7 +2065,8 @@ void BNPView::grabScreenshot(bool global)
     hideMainWindow();
 
     currentBasket()->saveInsertionData();
-    usleep(delay * 1000);
+
+    QThread::usleep(delay * 1000);
     m_regionGrabber = new RegionGrabber;
     connect(m_regionGrabber, SIGNAL(regionGrabbed(const QPixmap&)), this, SLOT(screenshotGrabbed(const QPixmap&)));
 }


### PR DESCRIPTION
It removes the need of the unistd.h and this means you don't need
anymore the kdewin dependency on Windows.
