### PR TITLE
XDG installation fixes

### DIFF
--- a/file-integration/CMakeLists.txt
+++ b/file-integration/CMakeLists.txt
@@ -10,14 +10,9 @@ install(TARGETS basketthumbcreator DESTINATION ${PLUGIN_INSTALL_DIR})
 ########### install files ###############
 
 find_package(SharedMimeInfo REQUIRED)
-find_program(XDG-DESKTOP-MENU_EXECUTABLE xdg-desktop-menu)
 
 install(FILES  basketthumbcreator.desktop DESTINATION ${SERVICES_INSTALL_DIR})
 install(FILES basket.xml DESTINATION ${XDG_MIME_INSTALL_DIR})
 update_xdg_mimetypes(${XDG_MIME_INSTALL_DIR})
-install(CODE "
-execute_process(COMMAND ${XDG-DESKTOP-MENU_EXECUTABLE} install
-  --novendor ${CMAKE_SOURCE_DIR}/src/basket.desktop)
-")
 
 kde4_install_icons(${ICON_INSTALL_DIR})


### PR DESCRIPTION
These commits fix the way the XDG mimetype XML is installed (i.e. now properly using the KDE-provided macros), and remove the wrong way the application basket.desktop is installed (twice).
