### PR TITLE
Implement user configurable plaintext pasting

### DIFF
--- a/src/aboutdata.cpp
+++ b/src/aboutdata.cpp
@@ -39,6 +39,10 @@ AboutData::AboutData()
     //Pass basket.kde.org to constructor to be used as D-Bus domain name, but set the displayed address below
     setHomepage("https://launchpad.net/basket");
 
+    addAuthor(ki18n("OmegaPhil"),
+              ki18n("Paste as plaintext option"),
+              "OmegaPhil@startmail.com");
+
     addAuthor(ki18n("Kelvie Wong"),
               ki18n("Maintainer"),
               "kelvie@ieee.org");

--- a/src/focusedwidgets.cpp
+++ b/src/focusedwidgets.cpp
@@ -28,6 +28,7 @@
 #include "bnpview.h"
 #include "basketscene.h"
 #include "global.h"
+#include "settings.h"
 
 #ifdef KeyPress
 #undef KeyPress
@@ -91,6 +92,20 @@ void FocusedTextEdit::enterEvent(QEvent *event)
 {
     emit mouseEntered();
     KTextEdit::enterEvent(event);
+}
+
+void FocusedTextEdit::insertFromMimeData(const QMimeData *source)
+{
+    // When user always wants plaintext pasting, if both HTML and text data is
+    // present, only send plain text data (the provided source is readonly and I
+    // also can't just pass it to QMimeData constructor as the latter is 'private')
+    if (Settings::pasteAsPlainText() && source->hasHtml() && source->hasText())
+    {
+        QMimeData alteredSource;
+        alteredSource.setData("text/plain", source->data("text/plain"));
+        KTextEdit::insertFromMimeData(&alteredSource);
+    }
+    else KTextEdit::insertFromMimeData(source);
 }
 
 /** class FocusWidgetFilter */

--- a/src/focusedwidgets.h
+++ b/src/focusedwidgets.h
@@ -39,6 +39,7 @@ protected:
     void keyPressEvent(QKeyEvent *event);
     void wheelEvent(QWheelEvent *event);
     void enterEvent(QEvent *event);
+    void insertFromMimeData (const QMimeData *source);
 signals:
     void escapePressed();
     void mouseEntered();

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -54,6 +54,7 @@ bool    Settings::s_showNotesToolTip     = true; // TODO: RENAME: useBasketToolt
 bool    Settings::s_confirmNoteDeletion  = true;
 bool    Settings::s_bigNotes             = false;
 bool    Settings::s_autoBullet           = true;
+bool    Settings::s_pasteAsPlainText     = false;
 bool    Settings::s_exportTextTags       = true;
 bool    Settings::s_useGnuPGAgent        = false;
 bool    Settings::s_treeOnLeft           = true;
@@ -127,6 +128,7 @@ void Settings::loadConfig()
     setShowNotesToolTip(config.readEntry("showNotesToolTip",     true));
     setBigNotes(config.readEntry("bigNotes",             false));
     setConfirmNoteDeletion(config.readEntry("confirmNoteDeletion",  true));
+    setPasteAsPlainText(config.readEntry("pasteAsPlainText",  false));
     setAutoBullet(config.readEntry("autoBullet",           true));
     setExportTextTags(config.readEntry("exportTextTags",       true));
     setUseGnuPGAgent(config.readEntry("useGnuPGAgent",        false));
@@ -210,6 +212,7 @@ void Settings::saveConfig()
     config.writeEntry("playAnimations",       playAnimations());
     config.writeEntry("showNotesToolTip",     showNotesToolTip());
     config.writeEntry("confirmNoteDeletion",  confirmNoteDeletion());
+    config.writeEntry("pasteAsPlainText",     pasteAsPlainText());
     config.writeEntry("bigNotes",             bigNotes());
     config.writeEntry("autoBullet",           autoBullet());
     config.writeEntry("exportTextTags",       exportTextTags());
@@ -544,6 +547,10 @@ BasketsPage::BasketsPage(QWidget * parent, const char * name)
     behaviorLayout->addWidget(m_confirmNoteDeletion);
     connect(m_confirmNoteDeletion, SIGNAL(stateChanged(int)), this, SLOT(changed()));
 
+    m_pasteAsPlainText = new QCheckBox(i18n("Do not keep text formatting when pasting"), behaviorBox);
+    behaviorLayout->addWidget(m_pasteAsPlainText);
+    connect(m_pasteAsPlainText, SIGNAL(stateChanged(int)), this, SLOT(changed()));
+
     QWidget *widget = new QWidget(behaviorBox);
     behaviorLayout->addWidget(widget);
     hLay = new QHBoxLayout(widget);
@@ -652,6 +659,7 @@ void BasketsPage::load()
 
     m_autoBullet->setChecked(Settings::autoBullet());
     m_confirmNoteDeletion->setChecked(Settings::confirmNoteDeletion());
+    m_pasteAsPlainText->setChecked(Settings::pasteAsPlainText());
     m_exportTextTags->setChecked(Settings::exportTextTags());
 
     m_groupOnInsertionLine->setChecked(Settings::groupOnInsertionLine());
@@ -681,6 +689,7 @@ void BasketsPage::save()
 
     Settings::setAutoBullet(m_autoBullet->isChecked());
     Settings::setConfirmNoteDeletion(m_confirmNoteDeletion->isChecked());
+    Settings::setPasteAsPlainText(m_pasteAsPlainText->isChecked());
     Settings::setExportTextTags(m_exportTextTags->isChecked());
 
     Settings::setGroupOnInsertionLine(m_groupOnInsertionLine->isChecked());

--- a/src/settings.h
+++ b/src/settings.h
@@ -94,6 +94,7 @@ private:
     QWidget             *m_groupOnInsertionLineWidget;
     QCheckBox           *m_groupOnInsertionLine;
     KComboBox           *m_middleAction;
+    QCheckBox           *m_pasteAsPlainText;
 
     // Protection
     QCheckBox           *m_useGnuPGAgent;
@@ -184,6 +185,7 @@ protected:
     static bool    s_confirmNoteDeletion;
     static bool    s_bigNotes;
     static bool    s_autoBullet;
+    static bool    s_pasteAsPlainText;
     static bool    s_exportTextTags;
     static bool    s_useGnuPGAgent;
     static bool    s_usePassivePopup;
@@ -249,6 +251,9 @@ public:  /* And the following methods are just getter / setters */
     }
     static inline bool    autoBullet()           {
         return s_autoBullet;
+    }
+    static inline bool    pasteAsPlainText()     {
+        return s_pasteAsPlainText;
     }
     static inline bool    exportTextTags()       {
         return s_exportTextTags;
@@ -411,6 +416,9 @@ public:  /* And the following methods are just getter / setters */
     }
     static inline void setConfirmNoteDeletion(bool confirm)     {
         s_confirmNoteDeletion  = confirm;
+    }
+    static inline void setPasteAsPlainText(bool yes)            {
+        s_pasteAsPlainText     = yes;
     }
     static void setBigNotes(bool big);
     static void setAutoBullet(bool yes);


### PR DESCRIPTION
This is my first programming work with basket - similar to [the user here](https://bugs.kde.org/show_bug.cgi?id=289177), I have wanted an ability to be able to paste anything as plaintext into a note (I use basket to maintain a collection of simple lists and don't need anything special beyond that, aside from tags).

This basic change allows me to do it based off a new 'Paste as plain text' setting in the Baskets page. This Works For Me™, and I'll continue testing it in real use.

What would you like changed so that this is accepted into the real codebase?

Thanks