### PR TITLE
Remove root-XML tag from application/x-basket-item

### DIFF
--- a/file-integration/basket.xml
+++ b/file-integration/basket.xml
@@ -50,6 +50,5 @@
         <match type="string" offset="39" value="!DOCTYPE basket>"/>
       </match>
     </magic>
-    <root-XML localName="basket" />
   </mime-type>
 </mime-info>


### PR DESCRIPTION
The tag needs a namespaceURI which does not make sense for its usage.