### PR TITLE
Use Unicode in aboutdata.cpp

### DIFF
--- a/src/aboutdata.cpp
+++ b/src/aboutdata.cpp
@@ -31,7 +31,7 @@ static const char description[] = I18N_NOOP(
 AboutData::AboutData()
         : KAboutData("basket", "", ki18n("BasKet Note Pads"),
                      VERSION, ki18n(description), KAboutData::License_GPL_V2,
-                     ki18n("(c) 2003-2007, S\303\251bastien Lao\303\273t, (c) 2013-2016, Gleb Baryshev"),
+                     ki18n("Copyright © 2003–2007, Sébastien Laoût; Copyright © 2013–2016, Gleb Baryshev"),
                      KLocalizedString(),
                      "http://basket.kde.org/",
                      "https://bugs.launchpad.net/basket")
@@ -47,11 +47,11 @@ AboutData::AboutData()
               ki18n("Maintainer"),
               "kelvie@ieee.org");
 
-    addAuthor(ki18n("S\303\251bastien Lao\303\273t"),
+    addAuthor(ki18n("Sébastien Laoût"),
               ki18n("Original Author"),
               "slaout@linux62.org");
 
-    addAuthor(ki18n("Petri Damst\303\251n"),
+    addAuthor(ki18n("Petri Damstén"),
               ki18n("Basket encryption, Kontact integration, KnowIt importer"),
               "damu@iki.fi");
 


### PR DESCRIPTION
Unicode works just fine. 1990’s workarounds with C octal escape codes and such are not needed.