### PR TITLE
Use QXmlStreamWriter instead of QDomDocument/QDomElement when saving XML files

### DIFF
--- a/src/archive.cpp
+++ b/src/archive.cpp
@@ -86,11 +86,17 @@ void Archive::save(BasketScene *basket, bool withSubBaskets, const QString &dest
     Archive::saveBasketToArchive(basket, withSubBaskets, &tar, backgrounds, tempFolder, &dialog);
 
     // Create a Small baskets.xml Document:
-    QDomDocument document("basketTree");
-    QDomElement root = document.createElement("basketTree");
-    document.appendChild(root);
-    Global::bnpView->saveSubHierarchy(Global::bnpView->listViewItemForBasket(basket), document, root, withSubBaskets);
-    BasketScene::safelySaveToFile(tempFolder + "baskets.xml", "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n" + document.toString());
+	QString data;
+	QXmlStreamWriter stream(&data);
+	stream.setAutoFormatting(true);
+	stream.setAutoFormattingIndent(1);
+	stream.writeStartDocument();
+	stream.writeDTD("<!DOCTYPE basketTree>");
+	stream.writeStartElement("basketTree");
+    Global::bnpView->saveSubHierarchy(Global::bnpView->listViewItemForBasket(basket), stream, withSubBaskets);
+	stream.writeEndElement();
+	stream.writeEndDocument();
+    BasketScene::safelySaveToFile(tempFolder + "baskets.xml", data);
     tar.addLocalFile(tempFolder + "baskets.xml", "baskets/baskets.xml");
     dir.remove(tempFolder + "baskets.xml");
 

--- a/src/archive.cpp
+++ b/src/archive.cpp
@@ -86,16 +86,16 @@ void Archive::save(BasketScene *basket, bool withSubBaskets, const QString &dest
     Archive::saveBasketToArchive(basket, withSubBaskets, &tar, backgrounds, tempFolder, &dialog);
 
     // Create a Small baskets.xml Document:
-	QString data;
-	QXmlStreamWriter stream(&data);
-	stream.setAutoFormatting(true);
-	stream.setAutoFormattingIndent(1);
-	stream.writeStartDocument();
-	stream.writeDTD("<!DOCTYPE basketTree>");
-	stream.writeStartElement("basketTree");
+    QString data;
+    QXmlStreamWriter stream(&data);
+    stream.setAutoFormatting(true);
+    stream.setAutoFormattingIndent(1);
+    stream.writeStartDocument();
+    stream.writeDTD("<!DOCTYPE basketTree>");
+    stream.writeStartElement("basketTree");
     Global::bnpView->saveSubHierarchy(Global::bnpView->listViewItemForBasket(basket), stream, withSubBaskets);
-	stream.writeEndElement();
-	stream.writeEndDocument();
+    stream.writeEndElement();
+    stream.writeEndDocument();
     BasketScene::safelySaveToFile(tempFolder + "baskets.xml", data);
     tar.addLocalFile(tempFolder + "baskets.xml", "baskets/baskets.xml");
     dir.remove(tempFolder + "baskets.xml");

--- a/src/basketscene.cpp
+++ b/src/basketscene.cpp
@@ -613,13 +613,13 @@ void BasketScene::saveNotes(QXmlStreamWriter &stream, Note *parent)
                 QString tags;
                 for (State::List::iterator it = note->states().begin(); it != note->states().end(); ++it)
                     tags += (tags.isEmpty() ? "" : ";") + (*it)->id();
-				stream.writeTextElement("tags", tags);
+                stream.writeTextElement("tags", tags);
             }
         } else {
             // Save Child Notes:
             saveNotes(stream, note);
-		}
-		stream.writeEndElement();
+        }
+        stream.writeEndElement();
         // Go to the Next One:
         note = note->next();
     }
@@ -671,35 +671,35 @@ void BasketScene::loadProperties(const QDomElement &properties)
 
 void BasketScene::saveProperties(QXmlStreamWriter &stream)
 {
-	stream.writeStartElement("properties");
+    stream.writeStartElement("properties");
 
-	stream.writeTextElement("name", basketName());
-	stream.writeTextElement("icon", icon());
+    stream.writeTextElement("name", basketName());
+    stream.writeTextElement("icon", icon());
 
-	stream.writeStartElement("appearance");
+    stream.writeStartElement("appearance");
     stream.writeAttribute("backgroundColor", backgroundColorSetting().isValid() ? backgroundColorSetting().name() : "");
     stream.writeAttribute("backgroundImage", backgroundImageName());
     stream.writeAttribute("textColor",       textColorSetting().isValid()       ? textColorSetting().name()       : "");
-	stream.writeEndElement();
+    stream.writeEndElement();
 
     stream.writeStartElement("disposition");
     stream.writeAttribute("columnCount", QString::number(columnsCount()));
     stream.writeAttribute("free",        XMLWork::trueOrFalse(isFreeLayout()));
     stream.writeAttribute("mindMap",     XMLWork::trueOrFalse(isMindMap()));
-	stream.writeEndElement();
+    stream.writeEndElement();
 
     stream.writeStartElement("shortcut");
     QString actionStrings[] = { "show", "globalShow", "globalSwitch" };
     stream.writeAttribute("action",      actionStrings[shortcutAction()]);
     stream.writeAttribute("combination", m_action->shortcut().toString());
-	stream.writeEndElement();
+    stream.writeEndElement();
 
     stream.writeStartElement("protection");
     stream.writeAttribute("key",  m_encryptionKey);
     stream.writeAttribute("type", QString::number(m_encryptionType));
-	stream.writeEndElement();
+    stream.writeEndElement();
 
-	stream.writeEndElement();
+    stream.writeEndElement();
 }
 
 void BasketScene::subscribeBackgroundImages()
@@ -920,24 +920,24 @@ bool BasketScene::save()
 
     DEBUG_WIN << "Basket[" + folderName() + "]: Saving...";
 
-	QString data;
-	QXmlStreamWriter stream(&data);
-	stream.setAutoFormatting(true);
-	stream.setAutoFormattingIndent(1);
-	stream.writeStartDocument();
-	stream.writeDTD("<!DOCTYPE basket>");
-	stream.writeStartElement("basket");
+    QString data;
+    QXmlStreamWriter stream(&data);
+    stream.setAutoFormatting(true);
+    stream.setAutoFormattingIndent(1);
+    stream.writeStartDocument();
+    stream.writeDTD("<!DOCTYPE basket>");
+    stream.writeStartElement("basket");
 
     // Create Properties Element and Populate It:
     saveProperties(stream);
 
     // Create Notes Element and Populate It:
-	stream.writeStartElement("notes");
-	saveNotes(stream, NULL);
-	stream.writeEndElement();
+    stream.writeStartElement("notes");
+    saveNotes(stream, NULL);
+    stream.writeEndElement();
 
-	stream.writeEndElement();
-	stream.writeEndDocument();
+    stream.writeEndElement();
+    stream.writeEndDocument();
 
     // Write to Disk:
     if (!saveToFile(fullPath() + ".basket", data)) {

--- a/src/basketscene.cpp
+++ b/src/basketscene.cpp
@@ -583,44 +583,43 @@ void BasketScene::loadNotes(const QDomElement &notes, Note *parent)
     }
 }
 
-void BasketScene::saveNotes(QDomDocument &document, QDomElement &element, Note *parent)
+void BasketScene::saveNotes(QXmlStreamWriter &stream, Note *parent)
 {
     Note *note = (parent ? parent->firstChild() : firstNote());
     while (note) {
         // Create Element:
-        QDomElement noteElement = document.createElement(note->isGroup() ? "group" : "note");
-        element.appendChild(noteElement);
+        stream.writeStartElement(note->isGroup() ? "group" : "note");
         // Free Note Properties:
         if (note->isFree()) {
-            noteElement.setAttribute("x", note->x());
-            noteElement.setAttribute("y", note->y());
+            stream.writeAttribute("x", QString::number(note->x()));
+            stream.writeAttribute("y", QString::number(note->y()));
         }
         // Resizeable Note Properties:
         if (note->hasResizer())
-            noteElement.setAttribute("width", note->groupWidth());
+            stream.writeAttribute("width", QString::number(note->groupWidth()));
         // Group Properties:
         if (note->isGroup() && !note->isColumn())
-            noteElement.setAttribute("folded", XMLWork::trueOrFalse(note->isFolded()));
+            stream.writeAttribute("folded", XMLWork::trueOrFalse(note->isFolded()));
         // Save Content:
         if (note->content()) {
             // Save Dates:
-            noteElement.setAttribute("added",            note->addedDate().toString(Qt::ISODate));
-            noteElement.setAttribute("lastModification", note->lastModificationDate().toString(Qt::ISODate));
+            stream.writeAttribute("added",            note->addedDate().toString(Qt::ISODate));
+            stream.writeAttribute("lastModification", note->lastModificationDate().toString(Qt::ISODate));
             // Save Content:
-            noteElement.setAttribute("type", note->content()->lowerTypeName());
-            QDomElement content = document.createElement("content");
-            noteElement.appendChild(content);
-            note->content()->saveToNode(document, content);
+            stream.writeAttribute("type", note->content()->lowerTypeName());
+            note->content()->saveToNode(stream);
             // Save Tags:
             if (note->states().count() > 0) {
                 QString tags;
                 for (State::List::iterator it = note->states().begin(); it != note->states().end(); ++it)
                     tags += (tags.isEmpty() ? "" : ";") + (*it)->id();
-                XMLWork::addElement(document, noteElement, "tags", tags);
+				stream.writeTextElement("tags", tags);
             }
-        } else
+        } else {
             // Save Child Notes:
-            saveNotes(document, noteElement, note);
+            saveNotes(stream, note);
+		}
+		stream.writeEndElement();
         // Go to the Next One:
         note = note->next();
     }
@@ -670,33 +669,37 @@ void BasketScene::loadProperties(const QDomElement &properties)
     setAppearance(icon, name, backgroundImage, backgroundColor, textColor); // Will emit propertiesChanged(this)
 }
 
-void BasketScene::saveProperties(QDomDocument &document, QDomElement &properties)
+void BasketScene::saveProperties(QXmlStreamWriter &stream)
 {
-    XMLWork::addElement(document, properties, "name", basketName());
-    XMLWork::addElement(document, properties, "icon", icon());
+	stream.writeStartElement("properties");
 
-    QDomElement appearance = document.createElement("appearance");
-    properties.appendChild(appearance);
-    appearance.setAttribute("backgroundImage", backgroundImageName());
-    appearance.setAttribute("backgroundColor", backgroundColorSetting().isValid() ? backgroundColorSetting().name() : "");
-    appearance.setAttribute("textColor",       textColorSetting().isValid()       ? textColorSetting().name()       : "");
+	stream.writeTextElement("name", basketName());
+	stream.writeTextElement("icon", icon());
 
-    QDomElement disposition = document.createElement("disposition");
-    properties.appendChild(disposition);
-    disposition.setAttribute("free",        XMLWork::trueOrFalse(isFreeLayout()));
-    disposition.setAttribute("columnCount", QString::number(columnsCount()));
-    disposition.setAttribute("mindMap",     XMLWork::trueOrFalse(isMindMap()));
+	stream.writeStartElement("appearance");
+    stream.writeAttribute("backgroundColor", backgroundColorSetting().isValid() ? backgroundColorSetting().name() : "");
+    stream.writeAttribute("backgroundImage", backgroundImageName());
+    stream.writeAttribute("textColor",       textColorSetting().isValid()       ? textColorSetting().name()       : "");
+	stream.writeEndElement();
 
-    QDomElement shortcut = document.createElement("shortcut");
-    properties.appendChild(shortcut);
+    stream.writeStartElement("disposition");
+    stream.writeAttribute("columnCount", QString::number(columnsCount()));
+    stream.writeAttribute("free",        XMLWork::trueOrFalse(isFreeLayout()));
+    stream.writeAttribute("mindMap",     XMLWork::trueOrFalse(isMindMap()));
+	stream.writeEndElement();
+
+    stream.writeStartElement("shortcut");
     QString actionStrings[] = { "show", "globalShow", "globalSwitch" };
-    shortcut.setAttribute("combination", m_action->shortcut().toString());
-    shortcut.setAttribute("action",      actionStrings[shortcutAction()]);
+    stream.writeAttribute("action",      actionStrings[shortcutAction()]);
+    stream.writeAttribute("combination", m_action->shortcut().toString());
+	stream.writeEndElement();
 
-    QDomElement protection = document.createElement("protection");
-    properties.appendChild(protection);
-    protection.setAttribute("type", m_encryptionType);
-    protection.setAttribute("key",  m_encryptionKey);
+    stream.writeStartElement("protection");
+    stream.writeAttribute("key",  m_encryptionKey);
+    stream.writeAttribute("type", QString::number(m_encryptionType));
+	stream.writeEndElement();
+
+	stream.writeEndElement();
 }
 
 void BasketScene::subscribeBackgroundImages()
@@ -917,23 +920,27 @@ bool BasketScene::save()
 
     DEBUG_WIN << "Basket[" + folderName() + "]: Saving...";
 
-    // Create Document:
-    QDomDocument document(/*doctype=*/"basket");
-    QDomElement root = document.createElement("basket");
-    document.appendChild(root);
+	QString data;
+	QXmlStreamWriter stream(&data);
+	stream.setAutoFormatting(true);
+	stream.setAutoFormattingIndent(1);
+	stream.writeStartDocument();
+	stream.writeDTD("<!DOCTYPE basket>");
+	stream.writeStartElement("basket");
 
     // Create Properties Element and Populate It:
-    QDomElement properties = document.createElement("properties");
-    saveProperties(document, properties);
-    root.appendChild(properties);
+    saveProperties(stream);
 
     // Create Notes Element and Populate It:
-    QDomElement notes = document.createElement("notes");
-    saveNotes(document, notes, 0);
-    root.appendChild(notes);
+	stream.writeStartElement("notes");
+	saveNotes(stream, NULL);
+	stream.writeEndElement();
+
+	stream.writeEndElement();
+	stream.writeEndDocument();
 
     // Write to Disk:
-    if (!saveToFile(fullPath() + ".basket", "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n" + document.toString())) {
+    if (!saveToFile(fullPath() + ".basket", data)) {
         DEBUG_WIN << "Basket[" + folderName() + "]: <font color=red>FAILED to save</font>!";
         return false;
 #ifdef HAVE_BALOO

--- a/src/basketscene.h
+++ b/src/basketscene.h
@@ -24,6 +24,7 @@
 #include <QtCore/QList>
 #include <QtCore/QSet>
 #include <QtCore/QTimer>
+#include <QXmlStreamWriter>
 #include <QtGui/QTextCursor>
 #include <QtGui/QClipboard>
 #include <QGraphicsScene>
@@ -241,14 +242,14 @@ private:
 
 private slots:
     void loadNotes(const QDomElement &notes, Note *parent);
-    void saveNotes(QDomDocument &document, QDomElement &element, Note *parent);
+    void saveNotes(QXmlStreamWriter &stream, Note *parent);
     void unlock();
 protected slots:
     void inactivityAutoLockTimeout();
 public slots:
     void load();
     void loadProperties(const QDomElement &properties);
-    void saveProperties(QDomDocument &document, QDomElement &properties);
+    void saveProperties(QXmlStreamWriter &stream);
     bool save();
     void commitEdit();
     void reload();

--- a/src/bnpview.cpp
+++ b/src/bnpview.cpp
@@ -996,19 +996,19 @@ void BNPView::save()
     DEBUG_WIN << "Basket Tree: Saving...";
 
 
-	QString data;
-	QXmlStreamWriter stream(&data);
-	stream.setAutoFormatting(true);
-	stream.setAutoFormattingIndent(1);
-	stream.writeStartDocument();
-	stream.writeDTD("<!DOCTYPE basketTree>");
-	stream.writeStartElement("basketTree");
+    QString data;
+    QXmlStreamWriter stream(&data);
+    stream.setAutoFormatting(true);
+    stream.setAutoFormattingIndent(1);
+    stream.writeStartDocument();
+    stream.writeDTD("<!DOCTYPE basketTree>");
+    stream.writeStartElement("basketTree");
 
     // Save Basket Tree:
     save(m_tree, 0, stream);
 
-	stream.writeEndElement();
-	stream.writeEndDocument();
+    stream.writeEndElement();
+    stream.writeEndDocument();
 
     // Write to Disk:
     BasketScene::safelySaveToFile(Global::basketsFolder() + "baskets.xml", data);
@@ -1028,10 +1028,10 @@ void BNPView::save(QTreeWidget *listView, QTreeWidgetItem* item, QXmlStreamWrite
         // For each basket:
         for (int i = 0; i < listView->topLevelItemCount(); i++) {
             item = listView->topLevelItem(i);
-			save(0, item, stream);
+            save(0, item, stream);
         }
     } else {
-		saveSubHierarchy(item, stream, true);
+        saveSubHierarchy(item, stream, true);
     }
 }
 
@@ -1052,14 +1052,14 @@ void BNPView::writeBasketElement(QTreeWidgetItem *item, QXmlStreamWriter &stream
 
 void BNPView::saveSubHierarchy(QTreeWidgetItem *item, QXmlStreamWriter &stream, bool recursive)
 {
-	stream.writeStartElement("basket");
+    stream.writeStartElement("basket");
     writeBasketElement(item, stream); //create root <basket>
     if (recursive) {
         for (int i = 0; i < item->childCount(); i++) {
-			saveSubHierarchy(item->child(i), stream, true);
-		}
+            saveSubHierarchy(item->child(i), stream, true);
+        }
     }
-	stream.writeEndElement();
+    stream.writeEndElement();
 }
 
 void BNPView::load()

--- a/src/bnpview.h
+++ b/src/bnpview.h
@@ -24,6 +24,7 @@
 #include <QtCore/QList>
 #include <QtGui/QClipboard>
 #include <QSplitter>
+#include <QXmlStreamWriter>
 
 #include <KXMLGUIClient>
 
@@ -98,7 +99,7 @@ public:
 
 private:
     //! Create <basket> element with <properties>
-    QDomElement createBasketElement(QTreeWidgetItem *item, QDomDocument &document, QDomElement &parentElement);
+    void writeBasketElement(QTreeWidgetItem *item, QXmlStreamWriter &steam);
 public slots:
     void countsChanged(BasketScene *basket);
     void notesStateChanged();
@@ -106,8 +107,8 @@ public slots:
 
     void updateBasketListViewItem(BasketScene *basket);
     void save();
-    void save(QTreeWidget* listView, QTreeWidgetItem *firstItem, QDomDocument &document, QDomElement &parentElement);
-    void saveSubHierarchy(QTreeWidgetItem *item, QDomDocument &document, QDomElement &parentElement, bool recursive);
+    void save(QTreeWidget* listView, QTreeWidgetItem *firstItem, QXmlStreamWriter &stream);
+    void saveSubHierarchy(QTreeWidgetItem *item, QXmlStreamWriter &stream, bool recursive);
     void load();
     void load(QTreeWidgetItem *item, const QDomElement &baskets);
     void loadNewBasket(const QString &folderName, const QDomElement &properties, BasketScene *parent);

--- a/src/bnpview.h
+++ b/src/bnpview.h
@@ -31,7 +31,6 @@
 #include "global.h"
 #include "basket_export.h"
 
-class QDomDocument;
 class QDomElement;
 
 class QStackedWidget;

--- a/src/notecontent.cpp
+++ b/src/notecontent.cpp
@@ -34,8 +34,8 @@
 #include <QtGui/QPainter>
 #include <QtGui/QPixmap>
 #include <QWidget>
-#include <QtXml/QDomDocument>
 #include <QtNetwork/QNetworkReply>
+#include <QtXml/QDomElement>
 #include <QTextBlock>
 #include <QTextCodec>
 #include <QMimeDatabase>

--- a/src/notecontent.cpp
+++ b/src/notecontent.cpp
@@ -101,11 +101,12 @@ NoteContent::NoteContent(Note *parent, const QString &fileName)
     setFileName(fileName);
 }
 
-void NoteContent::saveToNode(QDomDocument &doc, QDomElement &content)
+void NoteContent::saveToNode(QXmlStreamWriter &stream)
 {
     if (useFile()) {
-        QDomText textNode = doc.createTextNode(fileName());
-        content.appendChild(textNode);
+		stream.writeStartElement("content");
+		stream.writeCharacters(fileName());
+		stream.writeEndElement();
     }
 }
 
@@ -1694,14 +1695,15 @@ qreal LinkContent::setWidthAndGetHeight(qreal width)
     return m_linkDisplayItem.linkDisplay().height();
 }
 
-void LinkContent::saveToNode(QDomDocument &doc, QDomElement &content)
+void LinkContent::saveToNode(QXmlStreamWriter& stream)
 {
-    content.setAttribute("title",      title());
-    content.setAttribute("icon",       icon());
-    content.setAttribute("autoTitle", (autoTitle() ? "true" : "false"));
-    content.setAttribute("autoIcon", (autoIcon()  ? "true" : "false"));
-    QDomText textNode = doc.createTextNode(url().toDisplayString());
-    content.appendChild(textNode);
+	stream.writeStartElement("content");
+    stream.writeAttribute("title",      title());
+    stream.writeAttribute("icon",       icon());
+    stream.writeAttribute("autoIcon", (autoIcon()  ? "true" : "false"));
+    stream.writeAttribute("autoTitle", (autoTitle() ? "true" : "false"));
+    stream.writeCharacters(url().toDisplayString());
+	stream.writeEndElement();
 }
 
 
@@ -1952,12 +1954,13 @@ qreal CrossReferenceContent::setWidthAndGetHeight(qreal width)
     return m_linkDisplayItem.linkDisplay().height();
 }
 
-void CrossReferenceContent::saveToNode(QDomDocument &doc, QDomElement &content)
+void CrossReferenceContent::saveToNode(QXmlStreamWriter &stream)
 {
-    content.setAttribute("title",      title());
-    content.setAttribute("icon",       icon());
-    QDomText textNode = doc.createTextNode(url().toDisplayString());
-    content.appendChild(textNode);
+	stream.writeStartElement("content");
+    stream.writeAttribute("title",      title());
+    stream.writeAttribute("icon",       icon());
+    stream.writeCharacters(url().toDisplayString());
+	stream.writeEndElement();
 }
 
 void CrossReferenceContent::toolTipInfos(QStringList *keys, QStringList *values)
@@ -2277,10 +2280,11 @@ qreal ColorContent::setWidthAndGetHeight(qreal /*width*/) // We do not need widt
     return m_colorItem.boundingRect().height();
 }
 
-void ColorContent::saveToNode(QDomDocument &doc, QDomElement &content)
+void ColorContent::saveToNode(QXmlStreamWriter &stream)
 {
-    QDomText textNode = doc.createTextNode(color().name());
-    content.appendChild(textNode);
+	stream.writeStartElement("content");
+    stream.writeCharacters(color().name());
+	stream.writeEndElement();
 }
 
 void ColorContent::toolTipInfos(QStringList *keys, QStringList *values)

--- a/src/notecontent.cpp
+++ b/src/notecontent.cpp
@@ -104,9 +104,9 @@ NoteContent::NoteContent(Note *parent, const QString &fileName)
 void NoteContent::saveToNode(QXmlStreamWriter &stream)
 {
     if (useFile()) {
-		stream.writeStartElement("content");
-		stream.writeCharacters(fileName());
-		stream.writeEndElement();
+        stream.writeStartElement("content");
+        stream.writeCharacters(fileName());
+        stream.writeEndElement();
     }
 }
 
@@ -1697,13 +1697,13 @@ qreal LinkContent::setWidthAndGetHeight(qreal width)
 
 void LinkContent::saveToNode(QXmlStreamWriter& stream)
 {
-	stream.writeStartElement("content");
+    stream.writeStartElement("content");
     stream.writeAttribute("title",      title());
     stream.writeAttribute("icon",       icon());
     stream.writeAttribute("autoIcon", (autoIcon()  ? "true" : "false"));
     stream.writeAttribute("autoTitle", (autoTitle() ? "true" : "false"));
     stream.writeCharacters(url().toDisplayString());
-	stream.writeEndElement();
+    stream.writeEndElement();
 }
 
 
@@ -1956,11 +1956,11 @@ qreal CrossReferenceContent::setWidthAndGetHeight(qreal width)
 
 void CrossReferenceContent::saveToNode(QXmlStreamWriter &stream)
 {
-	stream.writeStartElement("content");
+    stream.writeStartElement("content");
     stream.writeAttribute("title",      title());
     stream.writeAttribute("icon",       icon());
     stream.writeCharacters(url().toDisplayString());
-	stream.writeEndElement();
+    stream.writeEndElement();
 }
 
 void CrossReferenceContent::toolTipInfos(QStringList *keys, QStringList *values)
@@ -2282,9 +2282,9 @@ qreal ColorContent::setWidthAndGetHeight(qreal /*width*/) // We do not need widt
 
 void ColorContent::saveToNode(QXmlStreamWriter &stream)
 {
-	stream.writeStartElement("content");
+    stream.writeStartElement("content");
     stream.writeCharacters(color().name());
-	stream.writeEndElement();
+    stream.writeEndElement();
 }
 
 void ColorContent::toolTipInfos(QStringList *keys, QStringList *values)

--- a/src/notecontent.h
+++ b/src/notecontent.h
@@ -32,7 +32,6 @@
 
 #include "linklabel.h"
 
-class QDomDocument;
 class QDomElement;
 
 class QBuffer;

--- a/src/notecontent.h
+++ b/src/notecontent.h
@@ -24,6 +24,7 @@
 #include <QtCore/QObject>
 #include <QGraphicsItem>
 #include <QUrl>
+#include <QXmlStreamWriter>
 
 #include <KIO/AccessManager>
 
@@ -130,7 +131,7 @@ public:
     virtual QString linkAt(const QPointF &/*pos*/)          {
         return "";
     } /// << @return the link anchor at position @p pos or "" if there is no link.
-    virtual void    saveToNode(QDomDocument &doc, QDomElement &content);  /// << Save the note in the basket XML file. By default it store the filename if a file is used.
+    virtual void    saveToNode(QXmlStreamWriter &stream);  /// << Save the note in the basket XML file. By default it store the filename if a file is used.
     virtual void    fontChanged()                                    = 0; /// << If your content display textual data, called when the font have changed (from tags or basket font)
     virtual void    linkLookChanged()                                  {} /// << If your content use LinkDisplay with preview enabled, reload the preview (can have changed size)
     virtual QString editToolTipText() const                          = 0; /// << @return "Edit this [text|image|...]" to put in the tooltip for the note's content zone.
@@ -521,7 +522,7 @@ public:
     void    exportToHTML(HTMLExporter *exporter, int indent);
     QString cssClass() const;
     qreal     setWidthAndGetHeight(qreal width);
-    void    saveToNode(QDomDocument &doc, QDomElement &content);
+    void    saveToNode(QXmlStreamWriter &stream);
     void    fontChanged();
     void    linkLookChanged();
     QString editToolTipText() const;
@@ -608,7 +609,7 @@ public:
     void    exportToHTML(HTMLExporter *exporter, int indent);
     QString cssClass() const;
     qreal     setWidthAndGetHeight(qreal);
-    void    saveToNode(QDomDocument &doc, QDomElement &content);
+    void    saveToNode(QXmlStreamWriter &stream);
     void    fontChanged();
     void    linkLookChanged();
     QString editToolTipText() const;
@@ -751,7 +752,7 @@ public:
     void    exportToHTML(HTMLExporter *exporter, int indent);
     QString cssClass() const;
     qreal     setWidthAndGetHeight(qreal width);
-    void    saveToNode(QDomDocument &doc, QDomElement &content);
+    void    saveToNode(QXmlStreamWriter &stream);
     void    fontChanged();
     QString editToolTipText() const;
     void    toolTipInfos(QStringList *keys, QStringList *values);


### PR DESCRIPTION
By design, QDomDocument does not save the ordering of element attributes.
Therefore, when converting a QDomDocument to QString, the order of attributes is random (actually it depends on the seed of the hashtables).

This breaks the use VCS, such as git, for managing basket main directory because the xml files get almost fully rewritten each time the ordering change.

This patch replaces calls to QDomDocument/QDomElement by calls QXmlStreamWriter which is the right way to generate XML files.
In addition to the deterministic ordering of attributes (ordering of calls), it is also much more efficient (no need to build the DOM in memory).